### PR TITLE
fix a bug that mainActivity shows up when dismiss splashActivity

### DIFF
--- a/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/AppSplashActivity.java
+++ b/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/AppSplashActivity.java
@@ -7,6 +7,7 @@ import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.animation.AnimationSet;
 import android.widget.ImageView;
 
 import com.hotbitmapgg.moequest.R;
@@ -38,6 +39,8 @@ public class AppSplashActivity extends Activity
 
     private Subscription subscribe;
 
+	private AnimatorSet mSplashSet;
+
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
@@ -65,11 +68,11 @@ public class AppSplashActivity extends Activity
         ObjectAnimator animatorX = ObjectAnimator.ofFloat(mSplashImage, "scaleX", 1f, SCALE_END);
         ObjectAnimator animatorY = ObjectAnimator.ofFloat(mSplashImage, "scaleY", 1f, SCALE_END);
 
-        AnimatorSet set = new AnimatorSet();
-        set.setDuration(ANIMATION_TIME).play(animatorX).with(animatorY);
-        set.start();
+        mSplashSet = new AnimatorSet();
+	    mSplashSet.setDuration(ANIMATION_TIME).play(animatorX).with(animatorY);
+	    mSplashSet.start();
 
-        set.addListener(new AnimatorListenerAdapter()
+	    mSplashSet.addListener(new AnimatorListenerAdapter()
         {
 
             @Override
@@ -92,6 +95,9 @@ public class AppSplashActivity extends Activity
         {
             subscribe.unsubscribe();
         }
+	    if (mSplashSet != null) {
+		    mSplashSet.removeAllListeners();
+	    }
     }
 
 }

--- a/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/AppSplashActivity.java
+++ b/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/AppSplashActivity.java
@@ -7,7 +7,6 @@ import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.animation.AnimationSet;
 import android.widget.ImageView;
 
 import com.hotbitmapgg.moequest.R;

--- a/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/MainActivity.java
+++ b/app/src/main/java/com/hotbitmapgg/moequest/module/commonality/MainActivity.java
@@ -8,6 +8,7 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.Toolbar;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
@@ -198,7 +199,7 @@ public class MainActivity extends RxBaseActivity
     }
 
 
-    public void switchFragment(Fragment fragment)
+    private void switchFragment(Fragment fragment)
     {
 
         FragmentTransaction trx = getSupportFragmentManager().beginTransaction();
@@ -218,7 +219,12 @@ public class MainActivity extends RxBaseActivity
 
         if (keyCode == KeyEvent.KEYCODE_BACK)
         {
-            logoutApp();
+
+	        if (mNavigationView.isShown()) {
+		        mDrawerLayout.closeDrawer(Gravity.START);
+	        } else {
+		        logoutApp();
+	        }
         }
 
         return true;


### PR DESCRIPTION
step:
open MoeQuest, then tap on back button when splash is still onscreen.
expect:
MoeQuest dismissed.
result:
MoeQuest will become active after 2 seconds.